### PR TITLE
Rollback exactly implementation for CYA_Account

### DIFF
--- a/CyberArkDsc/CYA_Account/CYA_Account.psm1
+++ b/CyberArkDsc/CYA_Account/CYA_Account.psm1
@@ -1,7 +1,54 @@
 ﻿enum Ensure {
     Absent
-    Exactly
     Present
+}
+
+function Get-LinkedAccounts {
+    param(
+        $AccountId
+    )
+
+    $PASSession = Get-PASSession
+
+    Add-Type @'
+    using System.Net;
+    using System.Security.Cryptography.X509Certificates;
+    public class TrustAllCertsPolicy : ICertificatePolicy {
+        public bool CheckValidationResult(
+            ServicePoint srvPoint, X509Certificate certificate,
+            WebRequest request, int certificateProblem) {
+            return true;
+        }
+    }
+'@
+    [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
+
+    $RestRequest = @{
+        Method      = 'Get'
+        Uri         = "$($PASSession.BaseUri)/api/ExtendedAccounts/$AccountId/LinkedAccounts"
+        WebSession  = $PASSession.WebSession
+        ContentType = 'application/json'
+    }
+
+    $Accounts = @()
+
+    $Response = Invoke-RestMethod @RestRequest | Select-Object -ExpandProperty LinkedAccounts
+
+    foreach ($LinkedAccount in $Response) {
+        if (-not [string]::isNullOrEmpty($LinkedAccount.Descriptor)) {
+            $LinkedAccountUserName = $LinkedAccount.Descriptor.Split('-')[1]
+            $LinkedAccountAddress = $LinkedAccount.Descriptor.Split('-')[2]
+            $LinkedAccountObject = Get-PASAccount -search "$LinkedAccountUserName $LinkedAccountAddress" | Where-Object { $_.UserName -eq $LinkedAccountUserName -and $_.Address -eq $LinkedAccountAddress }
+
+            $Accounts += @{
+                Name = $LinkedAccountObject.Name
+                Safe = $LinkedAccountObject.SafeName
+                Folder = 'root'
+                Type = $LinkedAccount.Name
+            }
+        }
+    }
+    return $Accounts
 }
 
 function Get-Account {
@@ -11,14 +58,14 @@ function Get-Account {
         [String]$PlatformId,
         [String]$SafeName,
         [String]$Name,
+        [hashtable]$ReconcileAccount,
+        [hashtable]$LogonAccount,
 
         [String] $PvwaUrl,
         [String] $AuthenticationType,
         [pscredential] $Credential,
         [bool] $SkipCertificateCheck
     )
-
-    $Properties = Get-AccountPropertiesFromPSBoundParameters $PSBoundParameters
 
     Get-CyberArkSession -PvwaUrl $PvwaUrl -Credential $Credential -AuthenticationType $AuthenticationType -SkipCertificateCheck $SkipCertificateCheck
 
@@ -27,14 +74,14 @@ function Get-Account {
     $CurrentState = [CYA_Account]::new()
 
     if ($ResourceExists) {
-        foreach ($Property in $Properties.GetEnumerator()) {
-            if ($ResourceExists.$($Property.Name) -ne $Property.Value) {
-                $CurrentState.Ensure = [Ensure]::Present
-                break
-            } else {
-                $CurrentState.Ensure = [Ensure]::Exactly
-            }
+        $CurrentState.Ensure = [Ensure]::Present
+
+        $LinkedAccounts = Get-LinkedAccounts -AccountId $ResourceExists.Id
+        foreach ($LinkedAccount in $LinkedAccounts) {
+            $CurrentState.$($LinkedAccount.Type) = $LinkedAccount
+            $CurrentState.$($LinkedAccount.Type).Remove('Type') | Out-Null
         }
+
         $CurrentState.UserName = $ResourceExists.UserName
         $CurrentState.Address = $ResourceExists.Address
         $CurrentState.PlatformId = $ResourceExists.PlatformId
@@ -58,6 +105,8 @@ function Set-Account {
         [String]$PlatformId,
         [String]$SafeName,
         [String]$Name,
+        [hashtable]$ReconcileAccount,
+        [hashtable]$LogonAccount,
 
         [String] $PvwaUrl,
         [String] $AuthenticationType,
@@ -69,45 +118,61 @@ function Set-Account {
 
     Get-CyberArkSession -PvwaUrl $PvwaUrl -Credential $Credential -AuthenticationType $AuthenticationType -SkipCertificateCheck $SkipCertificateCheck
 
-    $DesiredState = Test-Account -Ensure $Ensure -UserName $UserName -Address $Address -PlatformId $PlatformId -SafeName $SafeName -PvwaUrl $PvwaUrl -AuthenticationType $AuthenticationType -Credential $Credential -SkipCertificateCheck:$SkipCertificateCheck
+    switch ($Ensure) {
 
-    if (-not $DesiredState) {
+        'Absent' {
+            Get-PASAccount -safeName $SafeName -search "$UserName $Address" | Where-Object { $_.UserName -eq $UserName -and $_.Address -eq $Address } | Remove-PASAccount
+        }
 
-        switch ($Ensure) {
+        # TODO: Refactor all of this as it's ugly.
+        'Present' {
+            $Account = Get-Account -UserName $UserName -Address $Address -PvwaUrl $PvwaUrl -AuthenticationType $AuthenticationType -Credential $Credential -SkipCertificateCheck:$SkipCertificateCheck
 
-            'Absent' {
-                Get-PASAccount -safeName $SafeName -search "$UserName $Address" | Where-Object { $_.UserName -eq $UserName -and $_.Address -eq $Address } | Remove-PASAccount
-            }
+            if ([string]::isNullOrEmpty($Account.Id)) {
+                # Remove linked accounts as they need to be added after the account is created.
+                $Properties.Remove('ReconcileAccount') | Out-Null
+                $Properties.Remove('LogonAccount') | Out-Null
 
-            'Exactly' {
-                $Account = Get-Account -UserName $UserName -Address $Address -PvwaUrl $PvwaUrl -AuthenticationType $AuthenticationType -Credential $Credential -SkipCertificateCheck:$SkipCertificateCheck
+                $ResultingAccount = Add-PASAccount @Properties
 
-                if ([string]::isNullOrEmpty($Account.Id)) {
-                    Add-PASAccount @Properties
-                } else {
-                    $Actions = @()
+                if ($PSBoundParameters.ContainsKey('LogonAccount')) {
+                    $ResultingAccount | Set-PASLinkedAccount -safe $LogonAccount.Safe -folder $LogonAccount.Folder -name $LogonAccount.Name -extraPasswordIndex 1
+                }
 
-                    foreach ($Property in $Properties.GetEnumerator()) {
-                        if ($ResourceExists.$($Property.Name) -ne $Property.Value) {
-                            $Actions += @{
-                                op    = 'replace'
-                                path  = "/$($Property.Name)"
-                                value = $Property.Value
-                            }
+                if ($PSBoundParameters.ContainsKey('ReconcileAccount')) {
+                    $ResultingAccount | Set-PASLinkedAccount -safe $ReconcileAccount.Safe -folder $ReconcileAccount.Folder -name $ReconcileAccount.Name -extraPasswordIndex 3
+                }
+            } else {
+                $Properties.Remove('ReconcileAccount') | Out-Null
+                $Properties.Remove('LogonAccount') | Out-Null
+
+                if ($null -ne $LogonAccount) {
+                    Set-PASLinkedAccount -AccountId $Account.Id -safe $LogonAccount.Safe -folder $LogonAccount.Folder -name $LogonAccount.Name -extraPasswordIndex 1
+                }
+
+                if ($null -ne $ReconcileAccount) {
+                    Set-PASLinkedAccount -AccountId $Account.Id  -safe $ReconcileAccount.Safe -folder $ReconcileAccount.Folder -name $ReconcileAccount.Name -extraPasswordIndex 3
+                }
+
+                $Actions = @()
+
+                foreach ($Property in $Properties.GetEnumerator()) {
+                    if ($ResourceExists.$($Property.Name) -ne $Property.Value) {
+                        $Actions += @{
+                            op    = 'replace'
+                            path  = "/$($Property.Name)"
+                            value = $Property.Value
                         }
                     }
-                    if ($Actions.Count -gt 0) {
-                        Set-PASAccount -ID $Account.ID -operations $Actions
-                    }
                 }
-            }
-
-            'Present' {
-                Add-PASAccount @Properties
+                if ($Actions.Count -gt 0) {
+                    Set-PASAccount -ID $Account.ID -operations $Actions
+                }
             }
         }
     }
 }
+
 
 
 function Test-Account {
@@ -118,6 +183,8 @@ function Test-Account {
         [String]$PlatformId,
         [String]$SafeName,
         [String]$Name,
+        [hashtable]$ReconcileAccount,
+        [hashtable]$LogonAccount,
 
         [String] $PvwaUrl,
         [String] $AuthenticationType,
@@ -125,7 +192,7 @@ function Test-Account {
         [bool] $SkipCertificateCheck
     )
 
-    $DesiredState = $false
+    $DesiredState = $true
 
     $Properties = Get-AccountPropertiesFromPSBoundParameters $PSBoundParameters
 
@@ -133,24 +200,35 @@ function Test-Account {
 
     $CurrentState = Get-Account @Properties
 
-    switch ($Ensure) {
-
+    switch($Ensure) {
         'Absent' {
-            if ($CurrentState.Ensure -eq [Ensure]::Absent) {
-                $DesiredState = $true
+            if ($CurrentState.Ensure -ne 'Absent') {
+                $DesiredState = $false
             }
         }
-
-        'Exactly' {
-            if ($CurrentState.Ensure -eq [Ensure]::Exactly) {
-                $DesiredState = $true
-            }
-        }
-
         'Present' {
-            if ($CurrentState.Ensure -ne [Ensure]::Absent) {
-                $DesiredState = $true
+            if ($CurrentState.Ensure -ne 'Present') {
+                $DesiredState = $false
+                break
+            } else {
+                foreach ($Property in $Properties.GetEnumerator()) {
+                    if ($Property.Name -eq 'ReconcileAccount' -or $Property.Name -eq 'LogonAccount') {
+                        foreach ($LinkedAccountProperty in $Property.Value.GetEnumerator()) {
+                            if ($CurrentState.$($Property.Name).$($LinkedAccountProperty.Name) -ne $LinkedAccountProperty.Value) {
+                                $DesiredState = $false
+                                break
+                            }
+                        }
+
+                    } else {
+                        if ($CurrentState.$($Property.Name) -ne $Property.Value) {
+                            $DesiredState = $false
+                            break
+                        }
+                    }
+                }
             }
+
         }
     }
 
@@ -183,6 +261,12 @@ class CYA_Account {
     [DscProperty(NotConfigurable)]
     [string]$PlatformAccountProperties
 
+    [DscProperty()]
+    [System.Collections.Hashtable]$ReconcileAccount
+
+    [DscProperty()]
+    [System.Collections.Hashtable]$LogonAccount
+
     [DscProperty(Mandatory)]
     [string]$PvwaUrl
 
@@ -196,16 +280,16 @@ class CYA_Account {
     [bool]$SkipCertificateCheck
 
     [CYA_Account] Get() {
-        $Get = Get-Account -UserName $this.UserName -Address $this.Address -PlatformId $this.PlatformId -SafeName $this.SafeName -PvwaUrl $this.PvwaUrl -AuthenticationType $this.AuthenticationType -Credential $this.Credential -SkipCertificateCheck:$this.SkipCertificateCheck
+        $Get = Get-Account -UserName $this.UserName -Address $this.Address -PlatformId $this.PlatformId -SafeName $this.SafeName -ReconcileAccount $this.ReconcileAccount -LogonAccount $this.LogonAccount -PvwaUrl $this.PvwaUrl -AuthenticationType $this.AuthenticationType -Credential $this.Credential -SkipCertificateCheck:$this.SkipCertificateCheck
         return $Get
     }
 
     [void] Set() {
-        Set-Account -Ensure $this.Ensure -UserName $this.UserName -Address $this.Address -PlatformId $this.PlatformId -SafeName $this.SafeName -Name $this.Name -PvwaUrl $this.PvwaUrl -AuthenticationType $this.AuthenticationType -Credential $this.Credential -SkipCertificateCheck:$this.SkipCertificateCheck
+        Set-Account -Ensure $this.Ensure -UserName $this.UserName -Address $this.Address -PlatformId $this.PlatformId -SafeName $this.SafeName -Name $this.Name -ReconcileAccount $this.ReconcileAccount -LogonAccount $this.LogonAccount -PvwaUrl $this.PvwaUrl -AuthenticationType $this.AuthenticationType -Credential $this.Credential -SkipCertificateCheck:$this.SkipCertificateCheck
     }
 
     [bool] Test() {
-        $Test = Test-Account -Ensure $this.Ensure -UserName $this.UserName -Address $this.Address -PlatformId $this.PlatformId -SafeName $this.SafeName -PvwaUrl $this.PvwaUrl -AuthenticationType $this.AuthenticationType -Credential $this.Credential -SkipCertificateCheck:$this.SkipCertificateCheck
+        $Test = Test-Account -Ensure $this.Ensure -UserName $this.UserName -Address $this.Address -PlatformId $this.PlatformId -SafeName $this.SafeName -ReconcileAccount $this.ReconcileAccount -LogonAccount $this.LogonAccount -PvwaUrl $this.PvwaUrl -AuthenticationType $this.AuthenticationType -Credential $this.Credential -SkipCertificateCheck:$this.SkipCertificateCheck
         return $Test
     }
 }

--- a/CyberArkDsc/CYA_Safe/CYA_Safe.psm1
+++ b/CyberArkDsc/CYA_Safe/CYA_Safe.psm1
@@ -1,5 +1,6 @@
 ﻿enum Ensure {
     Absent
+    Exactly
     Present
 }
 
@@ -17,6 +18,8 @@ function Get-Safe {
         [bool]$SkipCertificateCheck
     )
 
+    $Properties = Get-AccountPropertiesFromPSBoundParameters $PSBoundParameters
+
     Get-CyberArkSession -PvwaUrl $PvwaUrl -Credential $Credential -AuthenticationType $AuthenticationType -SkipCertificateCheck $SkipCertificateCheck
 
     $CurrentState = [CYA_Safe]::new()
@@ -24,12 +27,20 @@ function Get-Safe {
     try {
         $ResourceExists = Get-PASSafe -SafeName $SafeName -ErrorAction SilentlyContinue | Select-Object -Property *
 
-        $CurrentState.Ensure = [Ensure]::Present
+        foreach ($Property in $Properties.GetEnumerator()) {
+            if ($ResourceExists.$($Property.Name) -ne $Property.Value) {
+                $CurrentState.Ensure = [Ensure]::Present
+                break
+            } else {
+                $CurrentState.Ensure = [Ensure]::Exactly
+            }
+        }
         $CurrentState.SafeName = $ResourceExists.SafeName
         $CurrentState.ManagingCPM = $ResourceExists.ManagingCPM
         $CurrentState.NumberOfDaysRetention = $ResourceExists.NumberOfDaysRetention
         $CurrentState.NumberOfVersionsRetention = $ResourceExists.NumberOfVersionsRetention
         $CurrentState.Description = $ResourceExists.Description
+        $CurrentState.SafeNumber = $ResourceExists.SafeNumber
     } catch {
         $CurrentState.Ensure = [Ensure]::Absent
     }
@@ -65,6 +76,22 @@ function Set-Safe {
 
             'Absent' {
                 Remove-PASSafe -SafeName $SafeName
+            }
+
+            'Exactly' {
+                $Safe = Get-Safe -SafeName $SafeName -PvwaUrl $PvwaUrl -Credential $Credential -AuthenticationType $AuthenticationType -SkipCertificateCheck $SkipCertificateCheck
+
+                if ([string]::isNullOrEmpty($Safe.SafeNumber)) {
+                    Add-PASSafe @Properties
+                } else {
+                    $SafeProperties = @{}
+                    foreach ($Property in $Properties.GetEnumerator()) {
+                        if ($ResourceExists.$($Property.Name) -ne $Property.Value) {
+                            $SafeProperties.Add($Property.Name, $Property.Value)
+                        }
+                    }
+                    Set-PASSafe @SafeProperties
+                }
             }
 
             'Present' {
@@ -103,6 +130,11 @@ function Test-Safe {
                 $isDesiredState = $true
             }
         }
+        'Exactly' {
+            if ($CurrentState.Ensure -eq [Ensure]::Exactly) {
+                $isDesiredState = $true
+            }
+        }
         'Present' {
             if ($CurrentState.Ensure -ne [Ensure]::Absent) {
                 $isDesiredState = $true
@@ -132,6 +164,9 @@ class CYA_Safe {
 
     [DscProperty()]
     [string]$Description
+
+    [DscProperty(NotConfigurable)]
+    [string]$SafeNumber
 
     [DscProperty(Mandatory)]
     [string]$PvwaUrl


### PR DESCRIPTION
`Absent` behavior is now what `Exactly` used to be. This also adds support for linked accounts therefore closes #8 